### PR TITLE
Fix bug when using keys named `en`

### DIFF
--- a/lib/clean_localization/client.rb
+++ b/lib/clean_localization/client.rb
@@ -35,12 +35,16 @@ module CleanLocalization
       value = self.class.data
 
       key_nodes.each do |k|
-        return value['en'] unless value[k]
+        return fallback(k, value) unless value[k]
 
         value = value[k]
       end
 
       value.freeze
+    end
+
+    def fallback(key, data)
+      data.is_a?(Hash) && data[key]
     end
 
     def insert_variables!(value, variables)

--- a/spec/clean_localization/client_spec.rb
+++ b/spec/clean_localization/client_spec.rb
@@ -8,6 +8,20 @@ describe CleanLocalization::Client do
     let(:key) { 'layout.login.button' }
     subject { client.translate(key) }
 
+    context 'when `en` exists as a key' do
+      context 'and key exists' do
+        let(:key) { 'languages.nl' }
+
+        it { is_expected.to eq 'Dutch' }
+      end
+
+      context 'and key does not exist' do
+        let(:key) { 'languages.jp' }
+
+        it { is_expected.to eq nil }
+      end
+    end
+
     context 'when valid key & lang' do
       it { is_expected.to eq 'Sign in!' }
     end

--- a/spec/clean_localization/config_spec.rb
+++ b/spec/clean_localization/config_spec.rb
@@ -5,6 +5,6 @@ describe CleanLocalization::Config do
     subject { described_class.load_data }
 
     it { is_expected.to be_a(Hash) }
-    it { expect(subject.keys).to match_array %w(dashboard layout cms instant_translation v2 messages) }
+    it { expect(subject.keys).to match_array %w(dashboard layout cms instant_translation v2 messages languages) }
   end
 end

--- a/spec/resources/languages.yml
+++ b/spec/resources/languages.yml
@@ -1,0 +1,7 @@
+languages:
+  en:
+    en: English
+    nl: Engels
+  nl:
+    en: Dutch
+    nl: Nederlands


### PR DESCRIPTION
Noticed this bug when using an actual `languages.yml` — a missing key would end up returning `{ en => "English" }`.