### PR TITLE
Ignore applying i18n to missing paths

### DIFF
--- a/lib/clean_localization/support/config_converter.rb
+++ b/lib/clean_localization/support/config_converter.rb
@@ -33,7 +33,7 @@ module CleanLocalization
         CleanLocalization::Config.file_paths.each do |original_path|
           filepath = original_path.gsub(CleanLocalization::Config.base_path.to_s, '')
           translated_path = translated_dir_path + filepath
-          apply_i18n(original_path, translated_path)
+          apply_i18n(original_path, translated_path) if File.exist?(translated_path)
         end
       end
 


### PR DESCRIPTION
I was given translations for just one file and wasn't able to apply it because it attempted to apply *all* translated files.